### PR TITLE
Updated XTBalanceUpdate.AccountId property type from string to long

### DIFF
--- a/XT.Net/Objects/Models/XTBalanceUpdate.cs
+++ b/XT.Net/Objects/Models/XTBalanceUpdate.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Text.Json.Serialization;
 using XT.Net.Enums;
 
@@ -15,7 +13,7 @@ namespace XT.Net.Objects.Models
         /// Account id
         /// </summary>
         [JsonPropertyName("a")]
-        public string AccountId { get; set; } = string.Empty;
+        public long AccountId { get; set; }
         /// <summary>
         /// Timestamp
         /// </summary>
@@ -26,7 +24,7 @@ namespace XT.Net.Objects.Models
         /// </summary>
         [JsonPropertyName("c")]
         public string Asset { get; set; } = string.Empty;
-        
+
         /// <summary>
         /// Frozen quantity
         /// </summary>


### PR DESCRIPTION
Fix for the following error:

`[Sckt 1] deserialization failed: [DeserializeError] Deserialize JsonException: The JSON value could not be converted to System.String. Path: $.data.a | LineNumber: 0 | BytePositionInLine: 62., Path: $.data.a, LineNumber: 0, LinePosition: 62 {"topic":"balance","event":"balance","data":{"a":1234567890123,"t":1740990799278,"c":"usdt","b":"1.483271","f":"1.17938962","z":"SPOT"}}`