### PR TITLE
Added internal ListenKey handling

### DIFF
--- a/XT.Net/Clients/FuturesApi/XTSocketClientFuturesApi.cs
+++ b/XT.Net/Clients/FuturesApi/XTSocketClientFuturesApi.cs
@@ -32,7 +32,7 @@ namespace XT.Net.Clients.FuturesApi
     /// <summary>
     /// Client providing access to the XT Futures websocket Api
     /// </summary>
-    internal partial class XTSocketClientFuturesApi : SocketApiClient<XTEnvironment, XTFuturesAuthenticationProvider, XTCredentials>, IXTSocketClientFuturesApi
+    internal partial class XTSocketClientFuturesApi : XTSocketApiClient<XTFuturesAuthenticationProvider>, IXTSocketClientFuturesApi
     {
         #region constructor/destructor
 
@@ -65,6 +65,29 @@ namespace XT.Net.Clients.FuturesApi
         /// <inheritdoc />
         protected override XTFuturesAuthenticationProvider CreateAuthenticationProvider(XTCredentials credentials)
             => new XTFuturesAuthenticationProvider(credentials);
+
+        /// <inheritdoc />
+        protected override Task<CallResult> RevitalizeRequestAsync(Subscription subscription)
+        {
+            // Refresh the listen key before resubscribing on a reconnected socket.
+            if (subscription is not IXTAuthenticatedSubscription authSubscription)
+                return Task.FromResult(CallResult.SuccessResult);
+
+            return RefreshSubscriptionListenKeyAsync(t => authSubscription.Token = t);
+        }
+
+        /// <inheritdoc />
+        protected override async Task<CallResult<string>> FetchListenKeyAsync()
+        {
+            using var restClient = new XTRestClient(opts =>
+            {
+                opts.ApiCredentials = ApiCredentials;
+                opts.Environment = ClientOptions.Environment;
+                opts.Proxy = ClientOptions.Proxy;
+                opts.RequestTimeout = ClientOptions.RequestTimeout;
+            });
+            return await restClient.UsdtFuturesApi.Account.GetListenKeyAsync().ConfigureAwait(false);
+        }
 
         /// <inheritdoc />
         public async Task<CallResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(string symbol, Action<DataEvent<XTFuturesTrade>> onMessage, CancellationToken ct = default)
@@ -348,6 +371,16 @@ namespace XT.Net.Clients.FuturesApi
         }
 
         /// <inheritdoc />
+        public async Task<CallResult<UpdateSubscription>> SubscribeToBalancesUpdatesAsync(Action<DataEvent<XTFuturesBalanceUpdate>> onMessage, CancellationToken ct = default)
+        {
+            var listenKey = await GetListenKeyAsync().ConfigureAwait(false);
+            if (!listenKey)
+                return new CallResult<UpdateSubscription>(listenKey.Error!);
+
+            return await SubscribeToBalancesUpdatesAsync(listenKey.Data, onMessage, ct).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
         public async Task<CallResult<UpdateSubscription>> SubscribeToPositionUpdatesAsync(string listenKey, Action<DataEvent<XTFuturesPositionUpdate>> onMessage, CancellationToken ct = default)
         {
             var internalHandler = new Action<DateTime, string?, XTSocketUpdate<XTFuturesPositionUpdate>>((receiveTime, originalData, data) =>
@@ -368,6 +401,16 @@ namespace XT.Net.Clients.FuturesApi
         }
 
         /// <inheritdoc />
+        public async Task<CallResult<UpdateSubscription>> SubscribeToPositionUpdatesAsync(Action<DataEvent<XTFuturesPositionUpdate>> onMessage, CancellationToken ct = default)
+        {
+            var listenKey = await GetListenKeyAsync().ConfigureAwait(false);
+            if (!listenKey)
+                return new CallResult<UpdateSubscription>(listenKey.Error!);
+
+            return await SubscribeToPositionUpdatesAsync(listenKey.Data, onMessage, ct).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
         public async Task<CallResult<UpdateSubscription>> SubscribeToOrderUpdatesAsync(string listenKey, Action<DataEvent<XTFuturesOrder>> onMessage, CancellationToken ct = default)
         {
             var internalHandler = new Action<DateTime, string?, XTSocketUpdate<XTFuturesOrder>>((receiveTime, originalData, data) =>
@@ -385,6 +428,16 @@ namespace XT.Net.Clients.FuturesApi
                 listenKey,
                 internalHandler);
             return await SubscribeAsync(BaseAddress.AppendPath("ws/user"), subscription, ct).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public async Task<CallResult<UpdateSubscription>> SubscribeToOrderUpdatesAsync(Action<DataEvent<XTFuturesOrder>> onMessage, CancellationToken ct = default)
+        {
+            var listenKey = await GetListenKeyAsync().ConfigureAwait(false);
+            if (!listenKey)
+                return new CallResult<UpdateSubscription>(listenKey.Error!);
+
+            return await SubscribeToOrderUpdatesAsync(listenKey.Data, onMessage, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
@@ -411,6 +464,16 @@ namespace XT.Net.Clients.FuturesApi
         }
 
         /// <inheritdoc />
+        public async Task<CallResult<UpdateSubscription>> SubscribeToUserTradeUpdatesAsync(Action<DataEvent<XTFuturesUserTradeUpdate>> onMessage, CancellationToken ct = default)
+        {
+            var listenKey = await GetListenKeyAsync().ConfigureAwait(false);
+            if (!listenKey)
+                return new CallResult<UpdateSubscription>(listenKey.Error!);
+
+            return await SubscribeToUserTradeUpdatesAsync(listenKey.Data, onMessage, ct).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
         public async Task<CallResult<UpdateSubscription>> SubscribeToNotificationUpdatesAsync(string listenKey, Action<DataEvent<XTNotification>> onMessage, CancellationToken ct = default)
         {
             var internalHandler = new Action<DateTime, string?, XTSocketUpdate<XTNotification>>((receiveTime, originalData, data) =>
@@ -428,6 +491,16 @@ namespace XT.Net.Clients.FuturesApi
                 listenKey,
                 internalHandler);
             return await SubscribeAsync(BaseAddress.AppendPath("ws/user"), subscription, ct).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public async Task<CallResult<UpdateSubscription>> SubscribeToNotificationUpdatesAsync(Action<DataEvent<XTNotification>> onMessage, CancellationToken ct = default)
+        {
+            var listenKey = await GetListenKeyAsync().ConfigureAwait(false);
+            if (!listenKey)
+                return new CallResult<UpdateSubscription>(listenKey.Error!);
+
+            return await SubscribeToNotificationUpdatesAsync(listenKey.Data, onMessage, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />

--- a/XT.Net/Clients/SpotApi/XTSocketClientSpotApi.cs
+++ b/XT.Net/Clients/SpotApi/XTSocketClientSpotApi.cs
@@ -32,7 +32,7 @@ namespace XT.Net.Clients.SpotApi
     /// <summary>
     /// Client providing access to the XT Spot websocket Api
     /// </summary>
-    internal partial class XTSocketClientSpotApi : SocketApiClient<XTEnvironment, XTSpotAuthenticationProvider, XTCredentials>, IXTSocketClientSpotApi
+    internal partial class XTSocketClientSpotApi : XTSocketApiClient<XTSpotAuthenticationProvider>, IXTSocketClientSpotApi
     {
         #region fields
         protected override ErrorMapping ErrorMapping => XTErrors.SpotSocketErrors;
@@ -70,6 +70,29 @@ namespace XT.Net.Clients.SpotApi
         /// <inheritdoc />
         protected override XTSpotAuthenticationProvider CreateAuthenticationProvider(XTCredentials credentials)
             => new XTSpotAuthenticationProvider(credentials);
+
+        /// <inheritdoc />
+        protected override Task<CallResult> RevitalizeRequestAsync(Subscription subscription)
+        {
+            // Refresh the listen key before resubscribing on a reconnected socket.
+            if (subscription is not IXTAuthenticatedSubscription authSubscription || authSubscription.Token == null)
+                return Task.FromResult(CallResult.SuccessResult);
+
+            return RefreshSubscriptionListenKeyAsync(t => authSubscription.Token = t);
+        }
+
+        /// <inheritdoc />
+        protected override async Task<CallResult<string>> FetchListenKeyAsync()
+        {
+            using var restClient = new XTRestClient(opts =>
+            {
+                opts.ApiCredentials = ApiCredentials;
+                opts.Environment = ClientOptions.Environment;
+                opts.Proxy = ClientOptions.Proxy;
+                opts.RequestTimeout = ClientOptions.RequestTimeout;
+            });
+            return await restClient.SpotApi.Account.GetWebsocketTokenAsync().ConfigureAwait(false);
+        }
 
         /// <inheritdoc />
         public async Task<CallResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(string symbol, Action<DataEvent<XTTradeUpdate>> onMessage, CancellationToken ct = default)
@@ -240,6 +263,16 @@ namespace XT.Net.Clients.SpotApi
         }
 
         /// <inheritdoc />
+        public async Task<CallResult<UpdateSubscription>> SubscribeToBalanceUpdatesAsync(Action<DataEvent<XTBalanceUpdate>> onMessage, CancellationToken ct = default)
+        {
+            var token = await GetListenKeyAsync().ConfigureAwait(false);
+            if (!token)
+                return new CallResult<UpdateSubscription>(token.Error!);
+
+            return await SubscribeToBalanceUpdatesAsync(token.Data, onMessage, ct).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
         public async Task<CallResult<UpdateSubscription>> SubscribeToOrderUpdatesAsync(string token, Action<DataEvent<XTOrderUpdate>> onMessage, CancellationToken ct = default)
         {
             var internalHandler = new Action<DateTime, string?, XTSocketUpdate<XTOrderUpdate>>((receiveTime, originalData, data) =>
@@ -265,6 +298,15 @@ namespace XT.Net.Clients.SpotApi
             return await SubscribeAsync(BaseAddress.AppendPath("private"), subscription, ct).ConfigureAwait(false);
         }
 
+        /// <inheritdoc />
+        public async Task<CallResult<UpdateSubscription>> SubscribeToOrderUpdatesAsync(Action<DataEvent<XTOrderUpdate>> onMessage, CancellationToken ct = default)
+        {
+            var token = await GetListenKeyAsync().ConfigureAwait(false);
+            if (!token)
+                return new CallResult<UpdateSubscription>(token.Error!);
+
+            return await SubscribeToOrderUpdatesAsync(token.Data, onMessage, ct).ConfigureAwait(false);
+        }
 
         /// <inheritdoc />
         public async Task<CallResult<UpdateSubscription>> SubscribeToUserTradeUpdatesAsync(string token, Action<DataEvent<XTUserTradeUpdate>> onMessage, CancellationToken ct = default)
@@ -290,7 +332,17 @@ namespace XT.Net.Clients.SpotApi
                 token);
             return await SubscribeAsync(BaseAddress.AppendPath("private"), subscription, ct).ConfigureAwait(false);
         }
-        
+
+        /// <inheritdoc />
+        public async Task<CallResult<UpdateSubscription>> SubscribeToUserTradeUpdatesAsync(Action<DataEvent<XTUserTradeUpdate>> onMessage, CancellationToken ct = default)
+        {
+            var token = await GetListenKeyAsync().ConfigureAwait(false);
+            if (!token)
+                return new CallResult<UpdateSubscription>(token.Error!);
+
+            return await SubscribeToUserTradeUpdatesAsync(token.Data, onMessage, ct).ConfigureAwait(false);
+        }
+
         /// <inheritdoc />
         public IXTSocketClientSpotApiShared SharedClient => this;
 

--- a/XT.Net/Clients/XTSocketApiClient.cs
+++ b/XT.Net/Clients/XTSocketApiClient.cs
@@ -1,0 +1,92 @@
+using CryptoExchange.Net.Authentication;
+using CryptoExchange.Net.Clients;
+using CryptoExchange.Net.Objects;
+using CryptoExchange.Net.Objects.Errors;
+using CryptoExchange.Net.Objects.Options;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+using XT.Net.Objects.Options;
+
+namespace XT.Net.Clients
+{
+    /// <summary>
+    /// Shared base for the XT spot and futures socket api clients. 
+    /// Provides a per-API-key listen-key cache and a helper that force-refreshes the cached value before a resubscribe
+    /// </summary>
+    internal abstract class XTSocketApiClient<TAuthProvider> : SocketApiClient<XTEnvironment, TAuthProvider, XTCredentials>
+        where TAuthProvider : AuthenticationProvider<XTCredentials>
+    {
+        // Conservative refresh interval. The documented TTL is longer, but server-side invalidations (e.g. another
+        // ws-token call from the same key) can shorten it. Refreshing every ~25 min is cheap and covers external
+        // invalidation cases.
+        private static readonly TimeSpan _listenKeyLifetime = TimeSpan.FromMinutes(25);
+        private static readonly TimeSpan _listenKeyRefreshSkew = TimeSpan.FromSeconds(5);
+
+        private readonly ConcurrentDictionary<string, CachedListenKey> _listenKeyCache = new();
+
+        /// <inheritdoc />
+        protected XTSocketApiClient(ILogger logger, string baseAddress, XTSocketOptions options, SocketApiOptions apiOptions)
+            : base(logger, baseAddress, options, apiOptions)
+        {
+        }
+
+        /// <summary>
+        /// Force-refresh the listen key from the REST endpoint and assign the new value to the subscription via the
+        /// supplied delegate. Intended to be called from a subclass's <c>RevitalizeRequestAsync</c> override before
+        /// each resubscribe.
+        /// </summary>
+        protected async Task<CallResult> RefreshSubscriptionListenKeyAsync(Action<string> assignListenKey)
+        {
+            var listenKey = await GetListenKeyAsync(forceRefresh: true).ConfigureAwait(false);
+            if (!listenKey)
+                return listenKey.AsDataless();
+
+            assignListenKey(listenKey.Data);
+            return CallResult.SuccessResult;
+        }
+
+        /// <summary>
+        /// Get a listen key for the configured API credentials, returning the cached value when it is still valid
+        /// and the caller did not request a force refresh.
+        /// </summary>
+        /// <param name="forceRefresh">Bypass the cache. Use after a reconnect, where the previous listen key has
+        /// likely been invalidated server-side.</param>
+        protected async Task<CallResult<string>> GetListenKeyAsync(bool forceRefresh = false)
+        {
+            if (ApiCredentials == null)
+                return new CallResult<string>(new NoApiCredentialsError());
+
+            var cacheKey = ApiCredentials.Key;
+            if (!forceRefresh
+                && _listenKeyCache.TryGetValue(cacheKey, out var cached)
+                && cached.Expire > DateTime.UtcNow)
+            {
+                return new CallResult<string>(cached.ListenKey);
+            }
+
+            _logger.LogDebug("[Sckt] Requesting fresh XT listen key for {Client} (forceRefresh={ForceRefresh})", GetType().Name, forceRefresh);
+            var result = await FetchListenKeyAsync().ConfigureAwait(false);
+            if (result)
+                _listenKeyCache[cacheKey] = new CachedListenKey { ListenKey = result.Data, Expire = DateTime.UtcNow + _listenKeyLifetime - _listenKeyRefreshSkew };
+            else
+                _logger.LogWarning("[Sckt] Failed to retrieve XT listen key for {Client}: {Error}", GetType().Name, result.Error);
+
+            return result;
+        }
+
+        /// <summary>
+        /// Subclass hook: call the REST endpoint that issues a websocket listen key for the configured API
+        /// credentials. The base class handles caching and refresh-on-reconnect; the subclass only needs to know
+        /// which endpoint to hit.
+        /// </summary>
+        protected abstract Task<CallResult<string>> FetchListenKeyAsync();
+
+        private sealed class CachedListenKey
+        {
+            public string ListenKey { get; set; } = string.Empty;
+            public DateTime Expire { get; set; }
+        }
+    }
+}

--- a/XT.Net/Clients/XTSocketClient.cs
+++ b/XT.Net/Clients/XTSocketClient.cs
@@ -48,7 +48,7 @@ namespace XT.Net.Clients
         public XTSocketClient(IOptions<XTSocketOptions> options, ILoggerFactory? loggerFactory = null) : base(loggerFactory, "XT")
         {
             Initialize(options.Value);
-                        
+
             FuturesApi = AddApiClient(new XTSocketClientFuturesApi(_logger, options.Value));
             SpotApi = AddApiClient(new XTSocketClientSpotApi(_logger, options.Value));
         }

--- a/XT.Net/Interfaces/Clients/FuturesApi/IXTSocketClientFuturesApi.cs
+++ b/XT.Net/Interfaces/Clients/FuturesApi/IXTSocketClientFuturesApi.cs
@@ -310,6 +310,21 @@ namespace XT.Net.Interfaces.Clients.FuturesApi
         Task<CallResult<UpdateSubscription>> SubscribeToBalancesUpdatesAsync(string listenKey, Action<DataEvent<XTFuturesBalanceUpdate>> onMessage, CancellationToken ct = default);
 
         /// <summary>
+        /// Subscribe to user balance updates. The listen key is requested internally using the configured API
+        /// credentials, cached, and automatically refreshed before each resubscribe (e.g. after a socket reconnect).
+        /// <para>
+        /// Docs:<br />
+        /// <a href="https://doc.xt.com/#futures_user_websocket_v2balance" /><br />
+        /// Endpoint:<br />
+        /// SUB /ws/user balance
+        /// </para>
+        /// </summary>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <param name="ct">Cancellation token for closing this subscription</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        Task<CallResult<UpdateSubscription>> SubscribeToBalancesUpdatesAsync(Action<DataEvent<XTFuturesBalanceUpdate>> onMessage, CancellationToken ct = default);
+
+        /// <summary>
         /// Subscribe to user position updates
         /// <para>
         /// Docs:<br />
@@ -323,6 +338,21 @@ namespace XT.Net.Interfaces.Clients.FuturesApi
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
         Task<CallResult<UpdateSubscription>> SubscribeToPositionUpdatesAsync(string listenKey, Action<DataEvent<XTFuturesPositionUpdate>> onMessage, CancellationToken ct = default);
+
+        /// <summary>
+        /// Subscribe to user position updates. The listen key is requested internally using the configured API
+        /// credentials, cached, and automatically refreshed before each resubscribe (e.g. after a socket reconnect).
+        /// <para>
+        /// Docs:<br />
+        /// <a href="https://doc.xt.com/#futures_user_websocket_v2position" /><br />
+        /// Endpoint:<br />
+        /// SUB /ws/user position
+        /// </para>
+        /// </summary>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <param name="ct">Cancellation token for closing this subscription</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        Task<CallResult<UpdateSubscription>> SubscribeToPositionUpdatesAsync(Action<DataEvent<XTFuturesPositionUpdate>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to user order updates
@@ -340,6 +370,21 @@ namespace XT.Net.Interfaces.Clients.FuturesApi
         Task<CallResult<UpdateSubscription>> SubscribeToOrderUpdatesAsync(string listenKey, Action<DataEvent<XTFuturesOrder>> onMessage, CancellationToken ct = default);
 
         /// <summary>
+        /// Subscribe to user order updates. The listen key is requested internally using the configured API
+        /// credentials, cached, and automatically refreshed before each resubscribe (e.g. after a socket reconnect).
+        /// <para>
+        /// Docs:<br />
+        /// <a href="https://doc.xt.com/#futures_user_websocket_v2order" /><br />
+        /// Endpoint:<br />
+        /// SUB /ws/user order
+        /// </para>
+        /// </summary>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <param name="ct">Cancellation token for closing this subscription</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        Task<CallResult<UpdateSubscription>> SubscribeToOrderUpdatesAsync(Action<DataEvent<XTFuturesOrder>> onMessage, CancellationToken ct = default);
+
+        /// <summary>
         /// Subscribe to user trade updates
         /// <para>
         /// Docs:<br />
@@ -355,6 +400,21 @@ namespace XT.Net.Interfaces.Clients.FuturesApi
         Task<CallResult<UpdateSubscription>> SubscribeToUserTradeUpdatesAsync(string listenKey, Action<DataEvent<XTFuturesUserTradeUpdate>> onMessage, CancellationToken ct = default);
 
         /// <summary>
+        /// Subscribe to user trade updates. The listen key is requested internally using the configured API
+        /// credentials, cached, and automatically refreshed before each resubscribe (e.g. after a socket reconnect).
+        /// <para>
+        /// Docs:<br />
+        /// <a href="https://doc.xt.com/#futures_user_websocket_v2trade" /><br />
+        /// Endpoint:<br />
+        /// SUB /ws/user trade
+        /// </para>
+        /// </summary>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <param name="ct">Cancellation token for closing this subscription</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        Task<CallResult<UpdateSubscription>> SubscribeToUserTradeUpdatesAsync(Action<DataEvent<XTFuturesUserTradeUpdate>> onMessage, CancellationToken ct = default);
+
+        /// <summary>
         /// Subscribe to user notifications
         /// <para>
         /// Docs:<br />
@@ -368,6 +428,21 @@ namespace XT.Net.Interfaces.Clients.FuturesApi
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
         Task<CallResult<UpdateSubscription>> SubscribeToNotificationUpdatesAsync(string listenKey, Action<DataEvent<XTNotification>> onMessage, CancellationToken ct = default);
+
+        /// <summary>
+        /// Subscribe to user notifications. The listen key is requested internally using the configured API
+        /// credentials, cached, and automatically refreshed before each resubscribe (e.g. after a socket reconnect).
+        /// <para>
+        /// Docs:<br />
+        /// <a href="https://doc.xt.com/#futures_user_websocket_v2notify" /><br />
+        /// Endpoint:<br />
+        /// SUB /ws/user notify
+        /// </para>
+        /// </summary>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <param name="ct">Cancellation token for closing this subscription</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        Task<CallResult<UpdateSubscription>> SubscribeToNotificationUpdatesAsync(Action<DataEvent<XTNotification>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Get the shared socket requests client. This interface is shared with other exchanges to allow for a common implementation for different exchanges.

--- a/XT.Net/Interfaces/Clients/SpotApi/IXTSocketClientSpotApi.cs
+++ b/XT.Net/Interfaces/Clients/SpotApi/IXTSocketClientSpotApi.cs
@@ -186,6 +186,21 @@ namespace XT.Net.Interfaces.Clients.SpotApi
         Task<CallResult<UpdateSubscription>> SubscribeToBalanceUpdatesAsync(string token, Action<DataEvent<XTBalanceUpdate>> onMessage, CancellationToken ct = default);
 
         /// <summary>
+        /// Subscribe to user balance updates. The websocket token is requested internally using the configured API credentials,
+        /// cached, and automatically refreshed before each resubscribe (e.g. after a socket reconnect).
+        /// <para>
+        /// Docs:<br />
+        /// <a href="https://doc.xt.com/#websocket_privatebalanceChange" /><br />
+        /// Endpoint:<br />
+        /// SUB /private balance
+        /// </para>
+        /// </summary>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <param name="ct">Cancellation token for closing this subscription</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        Task<CallResult<UpdateSubscription>> SubscribeToBalanceUpdatesAsync(Action<DataEvent<XTBalanceUpdate>> onMessage, CancellationToken ct = default);
+
+        /// <summary>
         /// Subscribe to user order updates
         /// <para>
         /// Docs:<br />
@@ -201,6 +216,21 @@ namespace XT.Net.Interfaces.Clients.SpotApi
         Task<CallResult<UpdateSubscription>> SubscribeToOrderUpdatesAsync(string token, Action<DataEvent<XTOrderUpdate>> onMessage, CancellationToken ct = default);
 
         /// <summary>
+        /// Subscribe to user order updates. The websocket token is requested internally using the configured API credentials,
+        /// cached, and automatically refreshed before each resubscribe (e.g. after a socket reconnect).
+        /// <para>
+        /// Docs:<br />
+        /// <a href="https://doc.xt.com/#websocket_privateorderChange" /><br />
+        /// Endpoint:<br />
+        /// SUB /private order
+        /// </para>
+        /// </summary>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <param name="ct">Cancellation token for closing this subscription</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        Task<CallResult<UpdateSubscription>> SubscribeToOrderUpdatesAsync(Action<DataEvent<XTOrderUpdate>> onMessage, CancellationToken ct = default);
+
+        /// <summary>
         /// Subscribe to user trade update
         /// <para>
         /// Docs:<br />
@@ -214,6 +244,21 @@ namespace XT.Net.Interfaces.Clients.SpotApi
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
         Task<CallResult<UpdateSubscription>> SubscribeToUserTradeUpdatesAsync(string token, Action<DataEvent<XTUserTradeUpdate>> onMessage, CancellationToken ct = default);
+
+        /// <summary>
+        /// Subscribe to user trade updates. The websocket token is requested internally using the configured API credentials,
+        /// cached, and automatically refreshed before each resubscribe (e.g. after a socket reconnect).
+        /// <para>
+        /// Docs:<br />
+        /// <a href="https://doc.xt.com/#websocket_privateorderDeal" /><br />
+        /// Endpoint:<br />
+        /// SUB /private trade
+        /// </para>
+        /// </summary>
+        /// <param name="onMessage">The event handler for the received data</param>
+        /// <param name="ct">Cancellation token for closing this subscription</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        Task<CallResult<UpdateSubscription>> SubscribeToUserTradeUpdatesAsync(Action<DataEvent<XTUserTradeUpdate>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Get the shared socket requests client. This interface is shared with other exchanges to allow for a common implementation for different exchanges.

--- a/XT.Net/Objects/Sockets/Subscriptions/IXTAuthenticatedSubscription.cs
+++ b/XT.Net/Objects/Sockets/Subscriptions/IXTAuthenticatedSubscription.cs
@@ -1,0 +1,13 @@
+namespace XT.Net.Objects.Sockets.Subscriptions
+{
+    /// <summary>
+    /// Marker for XT websocket subscriptions that carry a listen key / token in the subscribe payload.
+    /// </summary>
+    internal interface IXTAuthenticatedSubscription
+    {
+        /// <summary>
+        /// Listen key / websocket token sent with the subscribe and unsubscribe requests.
+        /// </summary>
+        string? Token { get; set; }
+    }
+}

--- a/XT.Net/Objects/Sockets/Subscriptions/XTFuturesAuthSubscription.cs
+++ b/XT.Net/Objects/Sockets/Subscriptions/XTFuturesAuthSubscription.cs
@@ -10,13 +10,15 @@ using XT.Net.Objects.Internal;
 
 namespace XT.Net.Objects.Sockets.Subscriptions
 {
-    /// <inheritdoc />
-    internal class XTFuturesAuthSubscription<T> : Subscription
+    /// <inheritdoc cref="Subscription" />
+    internal class XTFuturesAuthSubscription<T> : Subscription, IXTAuthenticatedSubscription
     {
         private readonly SocketApiClient _client;
         private readonly Action<DateTime, string?, XTSocketUpdate<T>> _handler;
-        private readonly string _listenKey;
         private readonly string _topic;
+
+        /// <inheritdoc />
+        public string? Token { get; set; }
 
         /// <summary>
         /// ctor
@@ -25,7 +27,7 @@ namespace XT.Net.Objects.Sockets.Subscriptions
         {
             _client = client;
             _handler = handler;
-            _listenKey = listenKey;
+            Token = listenKey;
             _topic = topic;
 
             MessageRouter = MessageRouter.CreateWithoutTopicFilter<XTSocketUpdate<T>>(topic, DoHandleMessage);
@@ -38,7 +40,7 @@ namespace XT.Net.Objects.Sockets.Subscriptions
             {
                 Id = ExchangeHelpers.NextId().ToString(),
                 Method = "subscribe",
-                Parameters = [_topic + "@" + _listenKey],
+                Parameters = [_topic + "@" + Token],
             }, _topic);
         }
 
@@ -49,7 +51,7 @@ namespace XT.Net.Objects.Sockets.Subscriptions
             {
                 Id = ExchangeHelpers.NextId().ToString(),
                 Method = "unsubscribe",
-                Parameters = [_topic + "@" + _listenKey],
+                Parameters = [_topic + "@" + Token],
             }, _topic);
         }
 

--- a/XT.Net/Objects/Sockets/Subscriptions/XTSubscription.cs
+++ b/XT.Net/Objects/Sockets/Subscriptions/XTSubscription.cs
@@ -11,15 +11,17 @@ using XT.Net.Objects.Internal;
 
 namespace XT.Net.Objects.Sockets.Subscriptions
 {
-    /// <inheritdoc />
-    internal class XTSubscription<T> : Subscription
+    /// <inheritdoc cref="Subscription" />
+    internal class XTSubscription<T> : Subscription, IXTAuthenticatedSubscription
     {
         private readonly SocketApiClient _client;
-        private readonly string? _token;
         private readonly Action<DateTime, string?, XTSocketUpdate<T>> _handler;
         private readonly string _topic;
         private readonly string[] _topics;
         private readonly string[]? _symbols;
+
+        /// <inheritdoc />
+        public string? Token { get; set; }
 
         /// <summary>
         /// ctor
@@ -28,13 +30,13 @@ namespace XT.Net.Objects.Sockets.Subscriptions
         {
             _client = client;
             _handler = handler;
-            _token = token;
+            Token = token;
             _topic = topic;
             _topics = symbols == null ? [topic] : symbols!.Select(x => $"{topic}@{x}").ToArray();
             _symbols = symbols;
 
             IndividualSubscriptionCount = symbols?.Length ?? 1;
-      
+
             MessageRouter = MessageRouter.CreateWithOptionalTopicFilters<XTSocketUpdate<T>>(
                                 topic,
                                 listenerIdentifiers == null ? symbols?.ToArray() : listenerIdentifiers.Select(x => x.Split('@')[1]).ToArray(), // When Matcher is removed this can be simplified
@@ -49,7 +51,7 @@ namespace XT.Net.Objects.Sockets.Subscriptions
                 Id = ExchangeHelpers.NextId().ToString(),
                 Method = "subscribe",
                 Parameters = _topics,
-                ListenKey = _token
+                ListenKey = Token
             }, null);
         }
 
@@ -61,7 +63,7 @@ namespace XT.Net.Objects.Sockets.Subscriptions
                 Id = ExchangeHelpers.NextId().ToString(),
                 Method = "unsubscribe",
                 Parameters = _topics,
-                ListenKey = _token,
+                ListenKey = Token,
             }, null);
         }
 


### PR DESCRIPTION
Added internal ListenKey handling.
This is useful for preventing a reconnection loop if an authorized connection needs to be reestablished where the ListenKey has already expired.