### PR TITLE
Add futures GetOpenOrdersAsync (list-open-order endpoint)

### DIFF
--- a/XT.Net/Clients/FuturesApi/XTRestClientFuturesApiTrading.cs
+++ b/XT.Net/Clients/FuturesApi/XTRestClientFuturesApiTrading.cs
@@ -174,6 +174,20 @@ namespace XT.Net.Clients.FuturesApi
 
         #endregion
 
+        #region Get Open Orders
+
+        /// <inheritdoc />
+        public async Task<WebCallResult<XTFuturesOrder[]>> GetOpenOrdersAsync(string? symbol = null, CancellationToken ct = default)
+        {
+            var parameters = new ParameterCollection();
+            parameters.AddOptional("symbol", symbol?.ToLowerInvariant());
+            var request = _definitions.GetOrCreate(HttpMethod.Get, "/future/trade/v1/order/list-open-order", XTExchange.RateLimiter.RestFutures, 1, true, limitGuard: new SingleLimitGuard(200, TimeSpan.FromSeconds(1), RateLimitWindowType.Sliding));
+            var result = await _baseClient.SendAsync<XTFuturesOrder[]>(request, parameters, ct).ConfigureAwait(false);
+            return result;
+        }
+
+        #endregion
+
         #region Cancel Order
 
         /// <inheritdoc />

--- a/XT.Net/Interfaces/Clients/FuturesApi/IXTRestClientFuturesApiTrading.cs
+++ b/XT.Net/Interfaces/Clients/FuturesApi/IXTRestClientFuturesApiTrading.cs
@@ -140,7 +140,20 @@ namespace XT.Net.Interfaces.Clients.FuturesApi
         /// <param name="pageSize">["<c>size</c>"] Page size</param>
         /// <param name="ct">Cancellation token</param>
         Task<WebCallResult<XTDataPage<XTFuturesOrder>>> GetOrdersAsync(string? symbol = null, OrderStatus? status = null, string? clientOrderId = null, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? pageSize = null, CancellationToken ct = default);
-        
+
+        /// <summary>
+        /// Get open orders (orders in the NEW or PARTIALLY_FILLED state) across all markets, or a single market when a symbol is specified
+        /// <para>
+        /// Docs:<br />
+        /// <a href="https://doc.xt.com/docs/futures/Order/ListOpenOrder" /><br />
+        /// Endpoint:<br />
+        /// GET /future/trade/v1/order/list-open-order
+        /// </para>
+        /// </summary>
+        /// <param name="symbol">["<c>symbol</c>"] Filter by symbol, for example `ETH_USDT`. When omitted, open orders for all symbols are returned</param>
+        /// <param name="ct">Cancellation token</param>
+        Task<WebCallResult<XTFuturesOrder[]>> GetOpenOrdersAsync(string? symbol = null, CancellationToken ct = default);
+
         /// <summary>
         /// Cancel an order
         /// <para>


### PR DESCRIPTION
## Summary

The USDT-M futures trading client (`IXTRestClientFuturesApiTrading`) currently exposes only `GetOrdersAsync`, which maps to the order-**history** endpoint `GET /future/trade/v1/order/list` (filtered by `state` + `startTime`/`endTime` + pagination).

XT also offers a dedicated **open-orders** endpoint, [`GET /future/trade/v1/order/list-open-order`](https://doc.xt.com/docs/futures/Order/ListOpenOrder), which returns only `NEW` / `PARTIALLY_FILLED` orders, takes an **optional** `symbol` (all markets when omitted), and has no time window or pagination. It's the futures analogue of the existing `SpotApi.Trading.GetOpenOrdersAsync` — but there was no futures wrapper for it.

This PR adds `FuturesApi.Trading.GetOpenOrdersAsync(string? symbol = null, CancellationToken ct = default)`.

Without it, callers that need a *complete* snapshot of currently-open futures orders have to fall back to the history endpoint and guess at its default time window — which risks missing an old resting order.

## Changes
- `IXTRestClientFuturesApiTrading.GetOpenOrdersAsync` (interface + XML docs)
- `XTRestClientFuturesApiTrading.GetOpenOrdersAsync` (implementation)

The implementation mirrors the existing spot `GetOpenOrdersAsync` (returns `XTFuturesOrder[]`, single GET, optional lowercased `symbol`) and the futures rate-limit guard used by the sibling `GetOrdersAsync`.

```csharp
public async Task<WebCallResult<XTFuturesOrder[]>> GetOpenOrdersAsync(string? symbol = null, CancellationToken ct = default)
{
    var parameters = new ParameterCollection();
    parameters.AddOptional("symbol", symbol?.ToLowerInvariant());
    var request = _definitions.GetOrCreate(HttpMethod.Get, "/future/trade/v1/order/list-open-order", XTExchange.RateLimiter.RestFutures, 1, true, limitGuard: new SingleLimitGuard(200, TimeSpan.FromSeconds(1), RateLimitWindowType.Sliding));
    var result = await _baseClient.SendAsync<XTFuturesOrder[]>(request, parameters, ct).ConfigureAwait(false);
    return result;
}
```

Builds clean against the current `main`. Note: I matched `HttpMethod.Get` to the sibling `order/list` futures query and the spot open-order endpoint; if XT actually expects POST here, happy to switch.