### PR TITLE
Fixed future socket reconnection for unauthenticated connections

### DIFF
--- a/XT.Net/Clients/FuturesApi/XTSocketClientFuturesApi.cs
+++ b/XT.Net/Clients/FuturesApi/XTSocketClientFuturesApi.cs
@@ -70,7 +70,7 @@ namespace XT.Net.Clients.FuturesApi
         protected override Task<CallResult> RevitalizeRequestAsync(Subscription subscription)
         {
             // Refresh the listen key before resubscribing on a reconnected socket.
-            if (subscription is not IXTAuthenticatedSubscription authSubscription)
+            if (subscription is not IXTAuthenticatedSubscription authSubscription || authSubscription.Token == null)
                 return Task.FromResult(CallResult.SuccessResult);
 
             return RefreshSubscriptionListenKeyAsync(t => authSubscription.Token = t);


### PR DESCRIPTION
Added additional validation in the `XTSocketClientFuturesApi.RevitalizeRequestAsync()` to fix socket reconnection for unauthenticated subscriptions.

This fixes a reconnection loop:
```log
2026-06-19 06:06:22.622 warn [Sckt 777] Ping response timeout, reconnecting 
2026-06-19 06:06:24.286 warn [Sckt 777] failed request revitalization: [NoApiCredentialsError.MissingCredentials] No credentials provided for private endpoint, set the `ApiCredentials` option in the client configuration 
2026-06-19 06:06:24.286 warn [Sckt 777] failed reconnect processing: [NoApiCredentialsError.MissingCredentials] No credentials provided for private endpoint, set the `ApiCredentials` option in the client configuration, reconnecting again 
2026-06-19 06:06:29.622 warn [Sckt 777] failed request revitalization: [NoApiCredentialsError.MissingCredentials] No credentials provided for private endpoint, set the `ApiCredentials` option in the client configuration 
...
```