### PR TITLE
Fix nullable XT memo flag

### DIFF
--- a/XT.Net/Objects/Models/XTAsset.cs
+++ b/XT.Net/Objects/Models/XTAsset.cs
@@ -118,7 +118,7 @@ namespace XT.Net.Objects.Models
         /// ["<c>isNeedMemo</c>"] Needs memo
         /// </summary>
         [JsonPropertyName("isNeedMemo")]
-        public bool NeedsMemo { get; set; }
+        public bool? NeedsMemo { get; set; }
         /// <summary>
         /// ["<c>businessNameI18n</c>"] Business name
         /// </summary>


### PR DESCRIPTION
Fix for the following log message:
`10:32:32.235 | Warning     | CryptoExchange | Received null bool value, but property type is not a nullable bool. Resolver: XTSourceGenerationContext`