### PR TITLE
Shared asset types

### DIFF
--- a/XT.Net/Clients/FuturesApi/XTRestClientFuturesApiShared.cs
+++ b/XT.Net/Clients/FuturesApi/XTRestClientFuturesApiShared.cs
@@ -190,7 +190,7 @@ namespace XT.Net.Clients.FuturesApi
 
         #region Futures Symbol client
 
-        SharedSymbolCatalog? IFuturesSymbolRestClient.FuturesSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicId, EnvironmentName, null);
+        SharedSymbolCatalog? IFuturesSymbolRestClient.FuturesSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_exchangeName, _topicId, EnvironmentName, null);
         GetFuturesSymbolsOptions IFuturesSymbolRestClient.GetFuturesSymbolsOptions { get; } = new GetFuturesSymbolsOptions(_exchangeName, false);
         async Task<HttpResult<SharedFuturesSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
         {

--- a/XT.Net/Clients/FuturesApi/XTRestClientFuturesApiShared.cs
+++ b/XT.Net/Clients/FuturesApi/XTRestClientFuturesApiShared.cs
@@ -190,6 +190,7 @@ namespace XT.Net.Clients.FuturesApi
 
         #region Futures Symbol client
 
+        SharedSymbolCatalog? IFuturesSymbolRestClient.FuturesSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicId, EnvironmentName, null);
         GetFuturesSymbolsOptions IFuturesSymbolRestClient.GetFuturesSymbolsOptions { get; } = new GetFuturesSymbolsOptions(_exchangeName, false);
         async Task<HttpResult<SharedFuturesSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
         {
@@ -201,29 +202,62 @@ namespace XT.Net.Clients.FuturesApi
             if (!result.Success)
                 return HttpResult.Fail<SharedFuturesSymbol[]>(result);
 
-            IEnumerable<XTFuturesSymbol> data = result.Data.Symbols;
-            if (request.TradingMode != null)
-                data = data.Where(x => request.TradingMode.Value.IsPerpetual() ? x.ContractType == ContractType.Perpetual : x.ContractType != ContractType.Perpetual);
+            var resultData =
+                 result.Data.Symbols
+                 .Select(x => ParseSymbol(x))
+                .ToArray();
 
+            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, resultData);
+            return HttpResult.Ok(result, SharedUtils.ApplySymbolFilter(resultData, request));
+        }
 
-            var response = HttpResult.Ok(result, data.Select(s => new SharedFuturesSymbol(
+        private SharedFuturesSymbol ParseSymbol(XTFuturesSymbol s)
+        {
+            var result = new SharedFuturesSymbol(
                     (s.ContractType == ContractType.Perpetual && s.UnderlyingType == UnderlyingType.UsdtBased) ? TradingMode.PerpetualLinear
                     : (s.ContractType != ContractType.Perpetual && s.UnderlyingType == UnderlyingType.UsdtBased) ? TradingMode.DeliveryLinear
                     : (s.ContractType == ContractType.Perpetual && s.UnderlyingType == UnderlyingType.UsdtBased) ? TradingMode.PerpetualInverse
                     : TradingMode.DeliveryInverse
                     , s.BaseAsset, s.QuoteAsset, s.Symbol, s.Status == SymbolStatus.Online)
-                {
-                    ContractSize = s.ContractSize,
-                    DeliveryTime = s.DeliveryDate,
-                    MinTradeQuantity = s.MinQuantity,
-                    MinNotionalValue = s.MinNotional,
-                    PriceStep = s.MinStepPrice,
-                    PriceDecimals = s.PricePrecision,
-                    QuantityDecimals = s.QuantityPrecision
-                }).ToArray());
+            {
+                ContractSize = s.ContractSize,
+                DeliveryTime = s.DeliveryDate,
+                MinTradeQuantity = s.MinQuantity,
+                MinNotionalValue = s.MinNotional,
+                PriceStep = s.MinStepPrice,
+                PriceDecimals = s.PricePrecision,
+                QuantityDecimals = s.QuantityPrecision,
+                DisplayName = s.EnglishName ?? s.Symbol
+            };
 
-            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, response.Data!);
-            return response;
+            if (result.TradingMode.IsInverse())
+            {
+                result.QuoteAssetType = SharedAssetType.Fiat;
+            }
+            else
+            {
+                result.QuoteAssetType = SharedAssetType.Crypto;
+                result.QuoteAssetSubType = SharedAssetSubType.StableCoin;
+            }
+
+            if (s.Labels.Contains("STOCK") || s.Tags.Contains("STOCK"))
+            {
+                result.BaseAssetType = SharedAssetType.TradFi;
+                result.BaseAssetSubType = SharedAssetSubType.Equity;
+            }
+            else if (s.Labels.Contains("METAL") || s.Tags.Contains("METAL")
+                || s.Labels.Contains("COMMODITY") || s.Tags.Contains("COMMODITY"))
+            {
+                result.BaseAssetType = SharedAssetType.TradFi;
+                result.BaseAssetSubType = SharedAssetSubType.Commodity;
+            }
+            else
+            {
+                result.BaseAssetType = SharedAssetType.Crypto;
+            }
+
+
+            return result;
         }
 
         async Task<ExchangeCallResult<SharedSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsForBaseAssetAsync(string baseAsset)

--- a/XT.Net/Clients/SpotApi/XTRestClientSpotApiShared.cs
+++ b/XT.Net/Clients/SpotApi/XTRestClientSpotApiShared.cs
@@ -499,7 +499,7 @@ namespace XT.Net.Clients.SpotApi
         #endregion
 
         #region Spot Symbol client
-        SharedSymbolCatalog? ISpotSymbolRestClient.SpotSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicId, EnvironmentName, null);
+        SharedSymbolCatalog? ISpotSymbolRestClient.SpotSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_exchangeName, _topicId, EnvironmentName, null);
         GetSpotSymbolsOptions ISpotSymbolRestClient.GetSpotSymbolsOptions { get; } = new GetSpotSymbolsOptions(_exchangeName, false);
 
         async Task<HttpResult<SharedSpotSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)

--- a/XT.Net/Clients/SpotApi/XTRestClientSpotApiShared.cs
+++ b/XT.Net/Clients/SpotApi/XTRestClientSpotApiShared.cs
@@ -499,6 +499,7 @@ namespace XT.Net.Clients.SpotApi
         #endregion
 
         #region Spot Symbol client
+        SharedSymbolCatalog? ISpotSymbolRestClient.SpotSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicId, EnvironmentName, null);
         GetSpotSymbolsOptions ISpotSymbolRestClient.GetSpotSymbolsOptions { get; } = new GetSpotSymbolsOptions(_exchangeName, false);
 
         async Task<HttpResult<SharedSpotSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
@@ -511,17 +512,49 @@ namespace XT.Net.Clients.SpotApi
             if (!result.Success)
                 return HttpResult.Fail<SharedSpotSymbol[]>(result);
 
-            var resultData = HttpResult.Ok(result, result.Data.Symbols.Select(s => new SharedSpotSymbol(s.BaseAsset, s.QuoteAsset, s.Symbol, s.SymbolStatus == SymbolStatus.Online)
+            var resultData =
+                 result.Data.Symbols
+                 .Select(x => ParseSymbol(x))
+                .ToArray();
+
+            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, resultData);
+            return HttpResult.Ok(result, SharedUtils.ApplySymbolFilter(resultData, request));
+        }
+
+        private SharedSpotSymbol ParseSymbol(XTSymbol s)
+        {
+            var result = new SharedSpotSymbol(s.BaseAsset, s.QuoteAsset, s.Symbol, s.SymbolStatus == SymbolStatus.Online)
             {
                 MinTradeQuantity = s.QuantityFilter?.MinQuantity,
                 MaxTradeQuantity = s.QuantityFilter?.MaxQuantity,
                 MinNotionalValue = s.QuoteQuantityFilter?.MinValue,
                 QuantityDecimals = s.QuantityPrecision,
-                PriceDecimals = s.PricePrecision
-            }).ToArray());
+                PriceDecimals = s.PricePrecision,
+                DisplayName = s.DisplayName,
+                QuoteAssetType = SharedAssetType.Crypto
+            };
 
-            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, resultData.Data!);
-            return resultData;
+            if (LibraryHelpers.IsStableCoin(s.QuoteAsset))
+                result.QuoteAssetSubType = SharedAssetSubType.StableCoin;
+
+            if (s.Tags.Contains("STOCKS"))
+            {
+                result.BaseAssetType = SharedAssetType.TradFi;
+                result.BaseAssetSubType = SharedAssetSubType.Equity;
+            }
+            else if (s.Tags.Contains("METALS"))
+            {
+                result.BaseAssetType = SharedAssetType.TradFi;
+                result.BaseAssetSubType = SharedAssetSubType.Commodity;
+            }
+            else
+            {
+                result.BaseAssetType = SharedAssetType.Crypto;
+                if (LibraryHelpers.IsStableCoin(result.BaseAsset)) 
+                    result.BaseAssetSubType = SharedAssetSubType.StableCoin;
+            }
+
+            return result;
         }
 
         async Task<ExchangeCallResult<SharedSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsForBaseAssetAsync(string baseAsset)

--- a/XT.Net/XT.Net.csproj
+++ b/XT.Net/XT.Net.csproj
@@ -53,12 +53,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="CryptoExchange.Net" Version="12.2.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.101">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\CryptoExchange.Net\CryptoExchange.Net\CryptoExchange.Net.csproj" />
   </ItemGroup>
 </Project>

--- a/XT.Net/XT.Net.csproj
+++ b/XT.Net/XT.Net.csproj
@@ -53,10 +53,12 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="CryptoExchange.Net" Version="12.1.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.101">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\CryptoExchange.Net\CryptoExchange.Net\CryptoExchange.Net.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Updated CryptoExchange.Net to v12.2.0 
Added SpotSymbolCatalog to Shared ISpotSymbolRestClient interface
Added FuturesSymbolCatalog to Shared IFuturesSymbolRestClient interface
Added BaseAssetType, BaseAssetSubType, QuoteAssetType and QuoteAssetSubType to GetSymbolsRequest model
Added DisplayName to SharedSpotSymbol and SharedFuturesSymbol models
Added BaseAssetType, BaseAssetSubType, QuoteAssetType and QuoteAssetSubType to SharedSpotSymbol and SharedFuturesSymbol models
Added DebuggerDisplay attributes to Shared models